### PR TITLE
RxJS Observable.create is deprecated

### DIFF
--- a/libs/nx-docker/src/builders/nx-docker/builder.ts
+++ b/libs/nx-docker/src/builders/nx-docker/builder.ts
@@ -9,7 +9,7 @@ export function runBuilder(
 ): Observable<BuilderOutput> {
   loadEnvVars(options.envFile);
 
-  return Observable.create(async (observer) => {
+  return new Observable((observer) => {
     if (!options.repository) {
       observer.next({
         success: false,
@@ -17,48 +17,47 @@ export function runBuilder(
           'ERROR: Bad builder config for @gperdomor/nx-docker - "repository" option is required',
       });
       observer.complete();
-      return;
-    }
+    } else {
+      try {
+        const workDir = '/code';
 
-    try {
-      const workDir = '/code';
+        const command = [`docker container run --rm -v ${context.workspaceRoot}:${workDir}`];
 
-      const command = [`docker container run --rm -v ${context.workspaceRoot}:${workDir}`];
-
-      if (options.socket) {
-        command.push(`-v ${options.socket}:/var/run/docker.sock`);
-      }
-
-      Object.keys(options).forEach((key) => {
-        if (options[key]) {
-          if (key === 'path' || key === 'dockerfile') {
-            command.push(`-e INPUT_${key.toUpperCase()}=${workDir}/${options[key]}`);
-          } else {
-            command.push(`-e INPUT_${key.toUpperCase()}=${options[key]}`);
-          }
+        if (options.socket) {
+          command.push(`-v ${options.socket}:/var/run/docker.sock`);
         }
-      });
 
-      if (options.tag_with_ref) {
-        command.push(`-e GITHUB_REF=${process.env.GITHUB_REF}`);
+        Object.keys(options).forEach((key) => {
+          if (options[key]) {
+            if (key === 'path' || key === 'dockerfile') {
+              command.push(`-e INPUT_${key.toUpperCase()}=${workDir}/${options[key]}`);
+            } else {
+              command.push(`-e INPUT_${key.toUpperCase()}=${options[key]}`);
+            }
+          }
+        });
+
+        if (options.tag_with_ref) {
+          command.push(`-e GITHUB_REF=${process.env.GITHUB_REF}`);
+        }
+
+        if (options.tag_with_sha) {
+          command.push(`-e GITHUB_SHA=${process.env.GITHUB_SHA}`);
+        }
+
+        if (process.env.DOCKER_BUILDKIT) {
+          command.push(`-e DOCKER_BUILDKIT=${process.env.DOCKER_BUILDKIT}`);
+        }
+
+        command.push(`docker/github-actions:v1.1.0 build-push`);
+
+        createProcess(command.join(' '), undefined, true, undefined).then((success) => {
+          observer.next({ success });
+          observer.complete();
+        });
+      } catch (e) {
+        observer.error(`ERROR: Something went wrong in @gperdomor/nx-docker - ${e.message}`);
       }
-
-      if (options.tag_with_sha) {
-        command.push(`-e GITHUB_SHA=${process.env.GITHUB_SHA}`);
-      }
-
-      if (process.env.DOCKER_BUILDKIT) {
-        command.push(`-e DOCKER_BUILDKIT=${process.env.DOCKER_BUILDKIT}`);
-      }
-
-      command.push(`docker/github-actions:v1.1.0 build-push`);
-
-      const success = await createProcess(command.join(' '), undefined, true, undefined);
-
-      observer.next({ success });
-      observer.complete();
-    } catch (e) {
-      observer.error(`ERROR: Something went wrong in @gperdomor/nx-docker - ${e.message}`);
     }
   });
 }


### PR DESCRIPTION
RxJS Observable.create was depericated in this Issue
https://github.com/ReactiveX/rxjs/issues/3982

`new Observabe()` should be used now.
Additionally `new Observable()` expects the return value to be a cleanup function. Thus changes were made to remove the `async/await` (as that would return a Promise) and the empty return.