### PR TITLE
fix(core): fix getInput to read valid env vars

### DIFF
--- a/packages/core/src/lib/core.ts
+++ b/packages/core/src/lib/core.ts
@@ -37,7 +37,7 @@ export enum ExitCode {
  * @returns   string
  */
 export const getInput = (name: string, fallback?: string, options?: InputOptions): string => {
-  const val: string = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || fallback || '';
+  const val: string = process.env[`INPUT_${name.replace(/[ -]/g, '_').toUpperCase()}`] || fallback || '';
   if (options && options.required && !val) {
     throw new Error(`Input required and not supplied: ${name}`);
   }

--- a/packages/nx-docker/src/executors/build/context.spec.ts
+++ b/packages/nx-docker/src/executors/build/context.spec.ts
@@ -7,7 +7,7 @@ describe('context', () => {
     env = process.env;
     process.env = {
       ...env,
-      'INPUT_BUILD-ARGS': 'arg1=value1\narg2=value2\narg3=value3',
+      INPUT_BUILD_ARGS: 'arg1=value1\narg2=value2\narg3=value3',
     };
   });
 


### PR DESCRIPTION
Fixes #34

---

To maintain some amount of backwards compatibility, I updated the regex in `getInput` to map both ` ` and `-` to `_`. This is ultimately not a backwards compatible change, however, since it would no longer read from `INPUT_BUILD-ARGS`, for example, if there's a shell that would allow that.