### PR TITLE
feat: azure devops pipeline support

### DIFF
--- a/packages/ci-context/src/lib/context.factory.ts
+++ b/packages/ci-context/src/lib/context.factory.ts
@@ -4,6 +4,7 @@ import * as circle from './utils/circle';
 import * as github from './utils/github';
 import * as gitlab from './utils/gitlab';
 import * as jenkins from './utils/jenkins';
+import * as azure from './utils/azure-devops';
 import * as local from './utils/local';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -33,6 +34,10 @@ export class ContextProxyFactory {
 
     if (ci.JENKINS) {
       return jenkins.context();
+    }
+
+    if (ci.AZURE_PIPELINES) {
+      return azure.context();
     }
 
     throw new Error('Unsupported CI provider');

--- a/packages/ci-context/src/lib/repo.factory.ts
+++ b/packages/ci-context/src/lib/repo.factory.ts
@@ -4,6 +4,7 @@ import * as circle from './utils/circle';
 import * as github from './utils/github';
 import * as gitlab from './utils/gitlab';
 import * as jenkins from './utils/jenkins';
+import * as azure from './utils/azure-devops';
 import * as local from './utils/local';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -33,6 +34,10 @@ export class RepoProxyFactory {
 
     if (ci.JENKINS) {
       return jenkins.repo();
+    }
+
+    if (ci.AZURE_PIPELINES) {
+      return azure.repo();
     }
 
     throw new Error('Unsupported CI provider');

--- a/packages/ci-context/src/lib/utils/azure-devops.spec.ts
+++ b/packages/ci-context/src/lib/utils/azure-devops.spec.ts
@@ -1,0 +1,67 @@
+import mockedEnv, { RestoreFn } from 'mocked-env';
+import { RunnerContext } from '../interfaces';
+import * as devops from './azure-devops';
+
+describe('Azure DevOps Context', () => {
+  let restore: RestoreFn;
+  let context: RunnerContext;
+
+  beforeEach(() => {
+    restore = mockedEnv(
+      {
+        BUILD_SOURCEVERSION: 'devops-sha',
+        BUILD_SOURCEVERSIONAUTHOR: 'devops-actor',
+        AGENT_JOBNAME: 'devops-job',
+        BUILD_BUILDID: '40',
+      },
+      { clear: true },
+    );
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  describe('When building pull requests', () => {
+    beforeEach(() => {
+      process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH = 'refs/heads/devops-ref-slug';
+      process.env.SYSTEM_PULLREQUEST_PULLREQUESTID = '123';
+    });
+
+    it('Should be take proper values', async () => {
+      context = await devops.context();
+
+      expect(context).toMatchObject({
+        actor: 'devops-actor',
+        eventName: 'pull_request',
+        job: 'devops-job',
+        payload: {},
+        ref: 'refs/heads/devops-ref-slug',
+        runId: 40,
+        runNumber: 40,
+        sha: 'devops-sha',
+      });
+    });
+  });
+
+  describe('When building branches', () => {
+    beforeEach(() => {
+      process.env.BUILD_SOURCEBRANCH = 'refs/heads/devops-ref-slug';
+    });
+
+    it('Should be take proper values', async () => {
+      context = await devops.context();
+
+      expect(context).toMatchObject({
+        actor: 'devops-actor',
+        eventName: 'unknown',
+        job: 'devops-job',
+        payload: {},
+        ref: 'refs/heads/devops-ref-slug',
+        runId: 40,
+        runNumber: 40,
+        sha: 'devops-sha',
+      });
+    });
+  });
+});

--- a/packages/ci-context/src/lib/utils/azure-devops.ts
+++ b/packages/ci-context/src/lib/utils/azure-devops.ts
@@ -1,0 +1,24 @@
+import { RepoMetadata, RunnerContext } from '../interfaces';
+
+export async function context(): Promise<RunnerContext> {
+  return {
+    actor: process.env.BUILD_SOURCEVERSIONAUTHOR || '',
+    eventName: process.env.SYSTEM_PULLREQUEST_PULLREQUESTID ? 'pull_request' : 'unknown',
+    job: process.env.AGENT_JOBNAME || '',
+    payload: {},
+    ref: process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH || (process.env.BUILD_SOURCEBRANCH as string),
+    runId: parseInt(process.env.BUILD_BUILDID || '0', 10),
+    runNumber: parseInt(process.env.BUILD_BUILDID || '0', 10),
+    sha: process.env.BUILD_SOURCEVERSION || '',
+  };
+}
+
+export async function repo(): Promise<RepoMetadata> {
+  return {
+    default_branch: '',
+    description: '',
+    html_url: process.env.BUILD_REPOSITORY_URI || '',
+    license: null,
+    name: process.env.AGENT_JOBNAME || '',
+  };
+}


### PR DESCRIPTION
Hi all, this is a really cool tool! Hoping we can implement it in our monorepo.

I'm trying to use `nx-docker` on Azure Devops but it seems the platform is not supported.

I took a quick look at the code and figured that these were the files required, but I haven't tested that this works since I'm not sure what the workflow for building and testing this would be.

That being said, I did check the env variables against a real build. [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml) is the official list.

Is there anything else we need to do to support building container images on Azure DevOps?

As a general comment, I think it would be better UX to return the `local` repo/context and log a warning when the platform is not supported. Perhaps a flag to force to use `local`?