### PR TITLE
chore: allow for prisma 4.x.x in peerDependencies

### DIFF
--- a/packages/nx-prisma/package.json
+++ b/packages/nx-prisma/package.json
@@ -20,7 +20,7 @@
     "@swc/helpers": "^0.4.3"
   },
   "peerDependencies": {
-    "prisma": "^3.15.0",
+    "prisma": "^3.15.0 || ^4.0.0",
     "ts-node": "*"
   }
 }


### PR DESCRIPTION
The `peerDependencies` are too strict for Prisma which is currently at v4.5.0.
As such, we've had to use `npm i --force` for a while now.