### PR TITLE
fix(nx-prisma): fixing generator schema description

### DIFF
--- a/packages/nx-prisma/src/generators/init/schema.json
+++ b/packages/nx-prisma/src/generators/init/schema.json
@@ -7,12 +7,12 @@
   "properties": {
     "project": {
       "type": "string",
-      "description": "The name of the project to add the Tailwind CSS setup for.",
+      "description": "The name of the project to add the Prisma setup to.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What project would you like to add the Tailwind CSS setup?"
+      "x-prompt": "What project would you like to add the Prisma setup to?"
     },
     "skipFormat": {
       "type": "boolean",


### PR DESCRIPTION
Thanks for your useful tooling!

Correcting the description and prompt of the prisma generator to remove "Tailwind" references.