### PR TITLE
chore(iss-650): update github ci readme to include github token

### DIFF
--- a/packages/nx-container/docs/ci/github-actions.md
+++ b/packages/nx-container/docs/ci/github-actions.md
@@ -33,7 +33,7 @@ jobs:
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
       - name: 'Build images'
-        run: npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=container --parallel=2
+        run: INPUT_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=container --parallel=2
 ```
 
 ## Example with Podman:


### PR DESCRIPTION
Fixes (updates docs) #650 

The github CI fails with a missing token when removing the temp build dir. adding 

```
INPUT_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} npx nx affected ....
```
fixed that. This PR updates the documentation to reflect that.