### PR TITLE
feat(nx-container): add a dependency on the build target

### DIFF
--- a/packages/nx-container/src/generators/init/generator.ts
+++ b/packages/nx-container/src/generators/init/generator.ts
@@ -28,6 +28,7 @@ export default async function (tree: Tree, options: InitGeneratorSchema) {
       ...project.targets,
       container: {
         executor: '@nx-tools/nx-container:build',
+        dependsOn: ['build'],
         options: {
           engine: options.engine,
           metadata: {


### PR DESCRIPTION
`dependsOn: ['build'],` will execute the `build` target before `container`.

```
        configurations: {
          production: {},
        },
```
is to add a `container:production` target that will execute the `build:production` first.        