### PR TITLE
feat(nx-prisma): remove cwd option from nx-prisma executions

### DIFF
--- a/packages/nx-prisma/src/executors/deploy/executor.spec.ts
+++ b/packages/nx-prisma/src/executors/deploy/executor.spec.ts
@@ -22,7 +22,11 @@ describe('Deploy Executor', () => {
   it('empty options', async () => {
     const options: DeployExecutorSchema = {};
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(expectCommandToHaveBeenCalled('npx prisma migrate deploy', [], 'workspace-root/apps/foo'));
+    expect(
+      expectCommandToHaveBeenCalled('npx prisma migrate deploy', [
+        '--schema=workspace-root/apps/foo/prisma/schema.prisma',
+      ])
+    );
     expect(output.success).toBeTruthy();
   });
 
@@ -33,9 +37,7 @@ describe('Deploy Executor', () => {
         [option]: value,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(
-        expectCommandToHaveBeenCalled('npx prisma migrate deploy', [`--${option}=${value}`], 'workspace-root/apps/foo')
-      );
+      expect(expectCommandToHaveBeenCalled('npx prisma migrate deploy', [`--${option}=${value}`]));
       expect(output.success).toBeTruthy();
     }
   );

--- a/packages/nx-prisma/src/executors/deploy/executor.ts
+++ b/packages/nx-prisma/src/executors/deploy/executor.ts
@@ -1,5 +1,6 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import { runCommand } from '../../run-commands';
+import { getDefaultScheme } from '../../utils';
 import { DeployExecutorSchema } from './schema';
 
 export default async function run(options: DeployExecutorSchema, ctx: ExecutorContext): Promise<{ success: true }> {
@@ -10,12 +11,11 @@ export default async function run(options: DeployExecutorSchema, ctx: ExecutorCo
   });
 }
 
-const getArgs = (options: DeployExecutorSchema): string[] => {
+const getArgs = (options: DeployExecutorSchema, ctx: ExecutorContext): string[] => {
   const args = [];
+  const schema = options?.schema ?? getDefaultScheme(ctx);
 
-  if (options?.schema) {
-    args.push(`--schema=${options.schema}`);
-  }
+  args.push(`--schema=${schema}`);
 
   return args;
 };

--- a/packages/nx-prisma/src/executors/generate/executor.spec.ts
+++ b/packages/nx-prisma/src/executors/generate/executor.spec.ts
@@ -18,15 +18,17 @@ const mockContext: Partial<ExecutorContext> = {
   projectName: 'foo',
 };
 
-export const expectCommandToHaveBeenCalled = (cmd: string, args: string[], cwd: string) => {
-  expect(getExecOutput).toHaveBeenCalledWith(cmd, args, { ignoreReturnCode: true, cwd });
+export const expectCommandToHaveBeenCalled = (cmd: string, args: string[]) => {
+  expect(getExecOutput).toHaveBeenCalledWith(cmd, args, { ignoreReturnCode: true });
 };
 
 describe('Generate Executor', () => {
   it('empty options', async () => {
     const options: GenerateExecutorSchema = {};
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(expectCommandToHaveBeenCalled('npx prisma generate', [], 'workspace-root/apps/foo'));
+    expect(
+      expectCommandToHaveBeenCalled('npx prisma generate', ['--schema=workspace-root/apps/foo/prisma/schema.prisma'])
+    );
     expect(output.success).toBeTruthy();
   });
 
@@ -37,7 +39,7 @@ describe('Generate Executor', () => {
         [option]: value,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(expectCommandToHaveBeenCalled('npx prisma generate', [`--${option}=${value}`], 'workspace-root/apps/foo'));
+      expect(expectCommandToHaveBeenCalled('npx prisma generate', [`--${option}=${value}`]));
       expect(output.success).toBeTruthy();
     }
   );
@@ -49,7 +51,12 @@ describe('Generate Executor', () => {
         [flag]: true,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(expectCommandToHaveBeenCalled('npx prisma generate', [`--${flag}`], 'workspace-root/apps/foo'));
+      expect(
+        expectCommandToHaveBeenCalled('npx prisma generate', [
+          '--schema=workspace-root/apps/foo/prisma/schema.prisma',
+          `--${flag}`,
+        ])
+      );
       expect(output.success).toBeTruthy();
     }
   );
@@ -62,11 +69,7 @@ describe('Generate Executor', () => {
     };
     const output = await executor(options, mockContext as ExecutorContext);
     expect(
-      expectCommandToHaveBeenCalled(
-        'npx prisma generate',
-        ['--schema=my-schema.schema', '--data-proxy', '--watch'],
-        'workspace-root/apps/foo'
-      )
+      expectCommandToHaveBeenCalled('npx prisma generate', ['--schema=my-schema.schema', '--data-proxy', '--watch'])
     );
     expect(output.success).toBeTruthy();
   });

--- a/packages/nx-prisma/src/executors/generate/executor.ts
+++ b/packages/nx-prisma/src/executors/generate/executor.ts
@@ -1,5 +1,6 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import { runCommand } from '../../run-commands';
+import { getDefaultScheme } from '../../utils';
 import { GenerateExecutorSchema } from './schema';
 
 export default async function run(options: GenerateExecutorSchema, ctx: ExecutorContext): Promise<{ success: true }> {
@@ -10,12 +11,11 @@ export default async function run(options: GenerateExecutorSchema, ctx: Executor
   });
 }
 
-const getArgs = (options: GenerateExecutorSchema): string[] => {
+const getArgs = (options: GenerateExecutorSchema, ctx: ExecutorContext): string[] => {
   const args = [];
+  const schema = options?.schema ?? getDefaultScheme(ctx);
 
-  if (options?.schema) {
-    args.push(`--schema=${options.schema}`);
-  }
+  args.push(`--schema=${schema}`);
 
   if (options?.['data-proxy']) {
     args.push('--data-proxy');

--- a/packages/nx-prisma/src/executors/migrate/executor.spec.ts
+++ b/packages/nx-prisma/src/executors/migrate/executor.spec.ts
@@ -1,10 +1,10 @@
 import { ExecutorContext } from '@nrwl/devkit';
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 import executor from './executor';
 import { MigrateExecutorSchema } from './schema';
 
-jest.mock('child_process', () => {
-  const originalModule = jest.requireActual('child_process');
+jest.mock('node:child_process', () => {
+  const originalModule = jest.requireActual('node:child_process');
   return {
     __esModule: true,
     ...originalModule,
@@ -22,27 +22,28 @@ describe('Migrate Executor', () => {
   it('empty options', async () => {
     const options: MigrateExecutorSchema = {};
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(execSync).toHaveBeenCalledWith(`npx prisma migrate dev`, {
-      cwd: 'workspace-root/apps/foo',
-      stdio: 'inherit',
-    });
+    expect(execSync).toHaveBeenCalledWith(
+      `npx prisma migrate dev --schema=workspace-root/apps/foo/prisma/schema.prisma`,
+      {
+        stdio: 'inherit',
+      }
+    );
     expect(output.success).toBeTruthy();
   });
 
-  test.each([
-    ['schema', 'my-prisma-file.schema'],
-    ['name', 'my first migration'],
-  ])(
+  test.each([['name', 'my first migration']])(
     'given %p option with %p value, should be handled has arg',
     async (option: keyof MigrateExecutorSchema, value: string) => {
       const options: MigrateExecutorSchema = {
         [option]: value,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(execSync).toHaveBeenCalledWith(`npx prisma migrate dev --${option}=${value}`, {
-        cwd: 'workspace-root/apps/foo',
-        stdio: 'inherit',
-      });
+      expect(execSync).toHaveBeenCalledWith(
+        `npx prisma migrate dev --schema=workspace-root/apps/foo/prisma/schema.prisma --${option}=${value}`,
+        {
+          stdio: 'inherit',
+        }
+      );
       expect(output.success).toBeTruthy();
     }
   );
@@ -54,10 +55,12 @@ describe('Migrate Executor', () => {
         [flag]: true,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(execSync).toHaveBeenCalledWith(`npx prisma migrate dev --${flag}`, {
-        cwd: 'workspace-root/apps/foo',
-        stdio: 'inherit',
-      });
+      expect(execSync).toHaveBeenCalledWith(
+        `npx prisma migrate dev --schema=workspace-root/apps/foo/prisma/schema.prisma --${flag}`,
+        {
+          stdio: 'inherit',
+        }
+      );
       expect(output.success).toBeTruthy();
     }
   );
@@ -73,7 +76,7 @@ describe('Migrate Executor', () => {
     const output = await executor(options, mockContext as ExecutorContext);
     expect(execSync).toHaveBeenCalledWith(
       'npx prisma migrate dev --schema=my-schema.schema --name=migration-name --create-only --skip-generate --skip-seed',
-      { cwd: 'workspace-root/apps/foo', stdio: 'inherit' }
+      { stdio: 'inherit' }
     );
     expect(output.success).toBeTruthy();
   });

--- a/packages/nx-prisma/src/executors/migrate/executor.ts
+++ b/packages/nx-prisma/src/executors/migrate/executor.ts
@@ -1,29 +1,27 @@
 import { ExecutorContext, getPackageManagerCommand } from '@nrwl/devkit';
-import { getProjectRoot, startGroup } from '@nx-tools/core';
-import { execSync } from 'child_process';
+import { startGroup } from '@nx-tools/core';
+import { execSync } from 'node:child_process';
+import { getDefaultScheme } from '../../utils';
 import { MigrateExecutorSchema } from './schema';
 
 export default async function run(options: MigrateExecutorSchema, ctx: ExecutorContext): Promise<{ success: true }> {
-  const cwd = getProjectRoot(ctx);
   const command = `${getPackageManagerCommand().exec} prisma migrate dev`;
-  const args = getArgs(options);
+  const args = getArgs(options, ctx);
 
   startGroup('Migrating Database', 'Nx Prisma');
 
   execSync([command, ...args].join(' '), {
-    cwd: cwd,
     stdio: 'inherit',
   });
 
   return { success: true };
 }
 
-const getArgs = (options: MigrateExecutorSchema): string[] => {
+const getArgs = (options: MigrateExecutorSchema, ctx: ExecutorContext): string[] => {
   const args = [];
+  const schema = options?.schema ?? getDefaultScheme(ctx);
 
-  if (options?.schema) {
-    args.push(`--schema=${options.schema}`);
-  }
+  args.push(`--schema=${schema}`);
 
   if (options?.name) {
     args.push(`--name=${options.name}`);

--- a/packages/nx-prisma/src/executors/pull/executor.spec.ts
+++ b/packages/nx-prisma/src/executors/pull/executor.spec.ts
@@ -22,7 +22,9 @@ describe('Pull Executor', () => {
   it('empty options', async () => {
     const options: PullExecutorSchema = {};
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(expectCommandToHaveBeenCalled('npx prisma db pull', [], 'workspace-root/apps/foo'));
+    expect(
+      expectCommandToHaveBeenCalled('npx prisma db pull', ['--schema=workspace-root/apps/foo/prisma/schema.prisma'])
+    );
     expect(output.success).toBeTruthy();
   });
 
@@ -33,7 +35,7 @@ describe('Pull Executor', () => {
         [option]: value,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(expectCommandToHaveBeenCalled('npx prisma db pull', [`--${option}=${value}`], 'workspace-root/apps/foo'));
+      expect(expectCommandToHaveBeenCalled('npx prisma db pull', [`--${option}=${value}`]));
       expect(output.success).toBeTruthy();
     }
   );
@@ -43,7 +45,12 @@ describe('Pull Executor', () => {
       [flag]: true,
     };
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(expectCommandToHaveBeenCalled('npx prisma db pull', [`--${flag}`], 'workspace-root/apps/foo'));
+    expect(
+      expectCommandToHaveBeenCalled('npx prisma db pull', [
+        '--schema=workspace-root/apps/foo/prisma/schema.prisma',
+        `--${flag}`,
+      ])
+    );
     expect(output.success).toBeTruthy();
   });
 
@@ -54,13 +61,7 @@ describe('Pull Executor', () => {
       print: true,
     };
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(
-      expectCommandToHaveBeenCalled(
-        'npx prisma db pull',
-        ['--schema=my-schema.schema', '--force', '--print'],
-        'workspace-root/apps/foo'
-      )
-    );
+    expect(expectCommandToHaveBeenCalled('npx prisma db pull', ['--schema=my-schema.schema', '--force', '--print']));
     expect(output.success).toBeTruthy();
   });
 });

--- a/packages/nx-prisma/src/executors/pull/executor.ts
+++ b/packages/nx-prisma/src/executors/pull/executor.ts
@@ -1,5 +1,6 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import { runCommand } from '../../run-commands';
+import { getDefaultScheme } from '../../utils';
 import { PullExecutorSchema } from './schema';
 
 export default async function run(options: PullExecutorSchema, ctx: ExecutorContext): Promise<{ success: true }> {
@@ -10,12 +11,11 @@ export default async function run(options: PullExecutorSchema, ctx: ExecutorCont
   });
 }
 
-const getArgs = (options: PullExecutorSchema): string[] => {
+const getArgs = (options: PullExecutorSchema, ctx: ExecutorContext): string[] => {
   const args = [];
+  const schema = options?.schema ?? getDefaultScheme(ctx);
 
-  if (options?.schema) {
-    args.push(`--schema=${options.schema}`);
-  }
+  args.push(`--schema=${schema}`);
 
   if (options?.force) {
     args.push('--force');

--- a/packages/nx-prisma/src/executors/push/executor.spec.ts
+++ b/packages/nx-prisma/src/executors/push/executor.spec.ts
@@ -22,7 +22,9 @@ describe('Push Executor', () => {
   it('empty options', async () => {
     const options: PushExecutorSchema = {};
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(expectCommandToHaveBeenCalled('npx prisma db push', [], 'workspace-root/apps/foo'));
+    expect(
+      expectCommandToHaveBeenCalled('npx prisma db push', ['--schema=workspace-root/apps/foo/prisma/schema.prisma'])
+    );
     expect(output.success).toBeTruthy();
   });
 
@@ -33,7 +35,7 @@ describe('Push Executor', () => {
         [option]: value,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(expectCommandToHaveBeenCalled('npx prisma db push', [`--${option}=${value}`], 'workspace-root/apps/foo'));
+      expect(expectCommandToHaveBeenCalled('npx prisma db push', [`--${option}=${value}`]));
       expect(output.success).toBeTruthy();
     }
   );
@@ -45,7 +47,12 @@ describe('Push Executor', () => {
         [flag]: true,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(expectCommandToHaveBeenCalled('npx prisma db push', [`--${flag}`], 'workspace-root/apps/foo'));
+      expect(
+        expectCommandToHaveBeenCalled('npx prisma db push', [
+          '--schema=workspace-root/apps/foo/prisma/schema.prisma',
+          `--${flag}`,
+        ])
+      );
       expect(output.success).toBeTruthy();
     }
   );
@@ -59,11 +66,12 @@ describe('Push Executor', () => {
     };
     const output = await executor(options, mockContext as ExecutorContext);
     expect(
-      expectCommandToHaveBeenCalled(
-        'npx prisma db push',
-        ['--schema=my-schema.schema', '--accept-data-loss', '--force-reset', '--skip-generate'],
-        'workspace-root/apps/foo'
-      )
+      expectCommandToHaveBeenCalled('npx prisma db push', [
+        '--schema=my-schema.schema',
+        '--accept-data-loss',
+        '--force-reset',
+        '--skip-generate',
+      ])
     );
     expect(output.success).toBeTruthy();
   });

--- a/packages/nx-prisma/src/executors/push/executor.ts
+++ b/packages/nx-prisma/src/executors/push/executor.ts
@@ -1,5 +1,6 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import { runCommand } from '../../run-commands';
+import { getDefaultScheme } from '../../utils';
 import { PushExecutorSchema } from './schema';
 
 export default async function run(options: PushExecutorSchema, ctx: ExecutorContext): Promise<{ success: true }> {
@@ -10,12 +11,11 @@ export default async function run(options: PushExecutorSchema, ctx: ExecutorCont
   });
 }
 
-const getArgs = (options: PushExecutorSchema): string[] => {
+const getArgs = (options: PushExecutorSchema, ctx: ExecutorContext): string[] => {
   const args = [];
+  const schema = options?.schema ?? getDefaultScheme(ctx);
 
-  if (options?.schema) {
-    args.push(`--schema=${options.schema}`);
-  }
+  args.push(`--schema=${schema}`);
 
   if (options?.['accept-data-loss']) {
     args.push('--accept-data-loss');

--- a/packages/nx-prisma/src/executors/reset/executor.spec.ts
+++ b/packages/nx-prisma/src/executors/reset/executor.spec.ts
@@ -1,10 +1,10 @@
 import { ExecutorContext } from '@nrwl/devkit';
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 import executor from './executor';
 import { ResetExecutorSchema } from './schema';
 
-jest.mock('child_process', () => {
-  const originalModule = jest.requireActual('child_process');
+jest.mock('node:child_process', () => {
+  const originalModule = jest.requireActual('node:child_process');
   return {
     __esModule: true,
     ...originalModule,
@@ -22,10 +22,12 @@ describe('Reset Executor', () => {
   it('empty options', async () => {
     const options: ResetExecutorSchema = {};
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(execSync).toHaveBeenCalledWith(`npx prisma migrate reset`, {
-      cwd: 'workspace-root/apps/foo',
-      stdio: 'inherit',
-    });
+    expect(execSync).toHaveBeenCalledWith(
+      `npx prisma migrate reset --schema=workspace-root/apps/foo/prisma/schema.prisma`,
+      {
+        stdio: 'inherit',
+      }
+    );
     expect(output.success).toBeTruthy();
   });
 
@@ -37,7 +39,6 @@ describe('Reset Executor', () => {
       };
       const output = await executor(options, mockContext as ExecutorContext);
       expect(execSync).toHaveBeenCalledWith(`npx prisma migrate reset --${option}=${value}`, {
-        cwd: 'workspace-root/apps/foo',
         stdio: 'inherit',
       });
       expect(output.success).toBeTruthy();
@@ -51,10 +52,12 @@ describe('Reset Executor', () => {
         [flag]: true,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(execSync).toHaveBeenCalledWith(`npx prisma migrate reset --${flag}`, {
-        cwd: 'workspace-root/apps/foo',
-        stdio: 'inherit',
-      });
+      expect(execSync).toHaveBeenCalledWith(
+        `npx prisma migrate reset --schema=workspace-root/apps/foo/prisma/schema.prisma --${flag}`,
+        {
+          stdio: 'inherit',
+        }
+      );
       expect(output.success).toBeTruthy();
     }
   );
@@ -69,7 +72,7 @@ describe('Reset Executor', () => {
     const output = await executor(options, mockContext as ExecutorContext);
     expect(execSync).toHaveBeenCalledWith(
       'npx prisma migrate reset --schema=my-schema.schema --force --skip-generate --skip-seed',
-      { cwd: 'workspace-root/apps/foo', stdio: 'inherit' }
+      { stdio: 'inherit' }
     );
     expect(output.success).toBeTruthy();
   });

--- a/packages/nx-prisma/src/executors/reset/executor.ts
+++ b/packages/nx-prisma/src/executors/reset/executor.ts
@@ -1,29 +1,27 @@
 import { ExecutorContext, getPackageManagerCommand } from '@nrwl/devkit';
-import { getProjectRoot, startGroup } from '@nx-tools/core';
-import { execSync } from 'child_process';
+import { startGroup } from '@nx-tools/core';
+import { execSync } from 'node:child_process';
+import { getDefaultScheme } from '../../utils';
 import { ResetExecutorSchema } from './schema';
 
 export default async function run(options: ResetExecutorSchema, ctx: ExecutorContext): Promise<{ success: true }> {
-  const cwd = getProjectRoot(ctx);
   const command = `${getPackageManagerCommand().exec} prisma migrate reset`;
-  const args = getArgs(options);
+  const args = getArgs(options, ctx);
 
   startGroup('Resetting Database', 'Nx Prisma');
 
   execSync([command, ...args].join(' '), {
-    cwd: cwd,
     stdio: 'inherit',
   });
 
   return { success: true };
 }
 
-const getArgs = (options: ResetExecutorSchema): string[] => {
+const getArgs = (options: ResetExecutorSchema, ctx: ExecutorContext): string[] => {
   const args = [];
+  const schema = options?.schema ?? getDefaultScheme(ctx);
 
-  if (options?.schema) {
-    args.push(`--schema=${options.schema}`);
-  }
+  args.push(`--schema=${schema}`);
 
   if (options?.force) {
     args.push('--force');

--- a/packages/nx-prisma/src/executors/resolve/executor.spec.ts
+++ b/packages/nx-prisma/src/executors/resolve/executor.spec.ts
@@ -49,7 +49,10 @@ describe('Resolve Executor', () => {
       };
       const output = await executor(options, mockContext as ExecutorContext);
       expect(
-        expectCommandToHaveBeenCalled('npx prisma migrate resolve', [`--${option}=${value}`], 'workspace-root/apps/foo')
+        expectCommandToHaveBeenCalled('npx prisma migrate resolve', [
+          '--schema=workspace-root/apps/foo/prisma/schema.prisma',
+          `--${option}=${value}`,
+        ])
       );
       expect(output.success).toBeTruthy();
     }
@@ -62,11 +65,10 @@ describe('Resolve Executor', () => {
     };
     const output = await executor(options, mockContext as ExecutorContext);
     expect(
-      expectCommandToHaveBeenCalled(
-        'npx prisma migrate resolve',
-        ['--schema=custom.schema', '--applied=add_users_table'],
-        'workspace-root/apps/foo'
-      )
+      expectCommandToHaveBeenCalled('npx prisma migrate resolve', [
+        '--schema=custom.schema',
+        '--applied=add_users_table',
+      ])
     );
     expect(output.success).toBeTruthy();
   });
@@ -78,11 +80,10 @@ describe('Resolve Executor', () => {
     };
     const output = await executor(options, mockContext as ExecutorContext);
     expect(
-      expectCommandToHaveBeenCalled(
-        'npx prisma migrate resolve',
-        ['--schema=custom.schema', '--rolled-back=add_users_table'],
-        'workspace-root/apps/foo'
-      )
+      expectCommandToHaveBeenCalled('npx prisma migrate resolve', [
+        '--schema=custom.schema',
+        '--rolled-back=add_users_table',
+      ])
     );
     expect(output.success).toBeTruthy();
   });

--- a/packages/nx-prisma/src/executors/resolve/executor.ts
+++ b/packages/nx-prisma/src/executors/resolve/executor.ts
@@ -1,5 +1,6 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import { runCommand } from '../../run-commands';
+import { getDefaultScheme } from '../../utils';
 import { ResolveExecutorSchema } from './schema';
 
 export default async function run(options: ResolveExecutorSchema, ctx: ExecutorContext): Promise<{ success: boolean }> {
@@ -14,12 +15,11 @@ export default async function run(options: ResolveExecutorSchema, ctx: ExecutorC
   });
 }
 
-const getArgs = (options: ResolveExecutorSchema): string[] => {
+const getArgs = (options: ResolveExecutorSchema, ctx: ExecutorContext): string[] => {
   const args = [];
+  const schema = options?.schema ?? getDefaultScheme(ctx);
 
-  if (options?.schema) {
-    args.push(`--schema=${options.schema}`);
-  }
+  args.push(`--schema=${schema}`);
 
   if (options?.['rolled-back']) {
     args.push(`--rolled-back=${options['rolled-back']}`);

--- a/packages/nx-prisma/src/executors/seed/executor.spec.ts
+++ b/packages/nx-prisma/src/executors/seed/executor.spec.ts
@@ -34,7 +34,12 @@ describe('Seed Executor', () => {
       script: 'custom-seed-file.ts',
     };
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(expectCommandToHaveBeenCalled('npx ts-node', ['custom-seed-file.ts'], 'workspace-folder/apps/foo'));
+    expect(
+      expectCommandToHaveBeenCalled('npx ts-node', [
+        '--project=workspace-folder/apps/foo/tsconfig.json',
+        'custom-seed-file.ts',
+      ])
+    );
     expect(output.success).toBeTruthy();
   });
 
@@ -44,13 +49,7 @@ describe('Seed Executor', () => {
       tsConfig: 'tsconfig.base.ts',
     };
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(
-      expectCommandToHaveBeenCalled(
-        'npx ts-node',
-        ['--project=tsconfig.base.ts', 'seed.ts'],
-        'workspace-folder/apps/foo'
-      )
-    );
+    expect(expectCommandToHaveBeenCalled('npx ts-node', ['--project=tsconfig.base.ts', 'seed.ts']));
     expect(output.success).toBeTruthy();
   });
 });

--- a/packages/nx-prisma/src/executors/status/executor.spec.ts
+++ b/packages/nx-prisma/src/executors/status/executor.spec.ts
@@ -22,7 +22,11 @@ describe('Status Executor', () => {
   it('empty options', async () => {
     const options: StatusExecutorSchema = {};
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(expectCommandToHaveBeenCalled('npx prisma migrate status', [], 'workspace-root/apps/foo'));
+    expect(
+      expectCommandToHaveBeenCalled('npx prisma migrate status', [
+        '--schema=workspace-root/apps/foo/prisma/schema.prisma',
+      ])
+    );
     expect(output.success).toBeTruthy();
   });
 
@@ -33,9 +37,7 @@ describe('Status Executor', () => {
         [option]: value,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(
-        expectCommandToHaveBeenCalled('npx prisma migrate status', [`--${option}=${value}`], 'workspace-root/apps/foo')
-      );
+      expect(expectCommandToHaveBeenCalled('npx prisma migrate status', [`--${option}=${value}`]));
       expect(output.success).toBeTruthy();
     }
   );

--- a/packages/nx-prisma/src/executors/status/executor.ts
+++ b/packages/nx-prisma/src/executors/status/executor.ts
@@ -1,5 +1,6 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import { runCommand } from '../../run-commands';
+import { getDefaultScheme } from '../../utils';
 import { StatusExecutorSchema } from './schema';
 
 export default async function run(options: StatusExecutorSchema, ctx: ExecutorContext): Promise<{ success: true }> {
@@ -10,12 +11,11 @@ export default async function run(options: StatusExecutorSchema, ctx: ExecutorCo
   });
 }
 
-const getArgs = (options: StatusExecutorSchema): string[] => {
+const getArgs = (options: StatusExecutorSchema, ctx: ExecutorContext): string[] => {
   const args = [];
+  const schema = options?.schema ?? getDefaultScheme(ctx);
 
-  if (options?.schema) {
-    args.push(`--schema=${options.schema}`);
-  }
+  args.push(`--schema=${schema}`);
 
   return args;
 };

--- a/packages/nx-prisma/src/executors/studio/executor.spec.ts
+++ b/packages/nx-prisma/src/executors/studio/executor.spec.ts
@@ -22,12 +22,13 @@ describe('Studio Executor', () => {
   it('empty options', async () => {
     const options: StudioExecutorSchema = {};
     const output = await executor(options, mockContext as ExecutorContext);
-    expect(expectCommandToHaveBeenCalled('npx prisma studio', [], 'workspace-root/apps/foo'));
+    expect(
+      expectCommandToHaveBeenCalled('npx prisma studio', ['--schema=workspace-root/apps/foo/prisma/schema.prisma'])
+    );
     expect(output.success).toBeTruthy();
   });
 
   test.each([
-    ['schema', 'my-prisma-file.schema'],
     ['browser', 'safari'],
     ['browser', 'chrome'],
     ['port', 5555],
@@ -38,7 +39,12 @@ describe('Studio Executor', () => {
         [option]: value,
       };
       const output = await executor(options, mockContext as ExecutorContext);
-      expect(expectCommandToHaveBeenCalled('npx prisma studio', [`--${option}=${value}`], 'workspace-root/apps/foo'));
+      expect(
+        expectCommandToHaveBeenCalled('npx prisma studio', [
+          '--schema=workspace-root/apps/foo/prisma/schema.prisma',
+          `--${option}=${value}`,
+        ])
+      );
       expect(output.success).toBeTruthy();
     }
   );
@@ -51,11 +57,11 @@ describe('Studio Executor', () => {
     };
     const output = await executor(options, mockContext as ExecutorContext);
     expect(
-      expectCommandToHaveBeenCalled(
-        'npx prisma studio',
-        ['--schema=my-schema.schema', '--browser=firefox', '--port=6666'],
-        'workspace-root/apps/foo'
-      )
+      expectCommandToHaveBeenCalled('npx prisma studio', [
+        '--schema=my-schema.schema',
+        '--browser=firefox',
+        '--port=6666',
+      ])
     );
     expect(output.success).toBeTruthy();
   });

--- a/packages/nx-prisma/src/executors/studio/executor.ts
+++ b/packages/nx-prisma/src/executors/studio/executor.ts
@@ -1,5 +1,6 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import { runCommand } from '../../run-commands';
+import { getDefaultScheme } from '../../utils';
 import { StudioExecutorSchema } from './schema';
 
 export default async function run(options: StudioExecutorSchema, ctx: ExecutorContext): Promise<{ success: true }> {
@@ -10,12 +11,11 @@ export default async function run(options: StudioExecutorSchema, ctx: ExecutorCo
   });
 }
 
-const getArgs = (options: StudioExecutorSchema): string[] => {
+const getArgs = (options: StudioExecutorSchema, ctx: ExecutorContext): string[] => {
   const args = [];
+  const schema = options?.schema ?? getDefaultScheme(ctx);
 
-  if (options?.schema) {
-    args.push(`--schema=${options.schema}`);
-  }
+  args.push(`--schema=${schema}`);
 
   if (options?.browser) {
     args.push(`--browser=${options.browser}`);

--- a/packages/nx-prisma/src/generators/init/generator.ts
+++ b/packages/nx-prisma/src/generators/init/generator.ts
@@ -32,31 +32,31 @@ export default async function (tree: Tree, options: InitGeneratorSchema): Promis
       ...project.targets,
       'prisma-generate': {
         executor: '@nx-tools/nx-prisma:generate',
-        options: { schema: 'prisma/schema.prisma' },
+        options: { schema: `${project.root}/prisma/schema.prisma` },
       },
       'prisma-migrate': {
         executor: '@nx-tools/nx-prisma:migrate',
-        options: { schema: 'prisma/schema.prisma' },
+        options: { schema: `${project.root}/prisma/schema.prisma` },
       },
       'prisma-pull': {
         executor: '@nx-tools/nx-prisma:pull',
-        options: { schema: 'prisma/schema.prisma' },
+        options: { schema: `${project.root}/prisma/schema.prisma` },
       },
       'prisma-push': {
         executor: '@nx-tools/nx-prisma:push',
-        options: { schema: 'prisma/schema.prisma' },
+        options: { schema: `${project.root}/prisma/schema.prisma` },
       },
       'prisma-deploy': {
         executor: '@nx-tools/nx-prisma:deploy',
-        options: { schema: 'prisma/schema.prisma' },
+        options: { schema: `${project.root}/prisma/schema.prisma` },
       },
       'prisma-status': {
         executor: '@nx-tools/nx-prisma:status',
-        options: { schema: 'prisma/schema.prisma' },
+        options: { schema: `${project.root}/prisma/schema.prisma` },
       },
       'prisma-studio': {
         executor: '@nx-tools/nx-prisma:studio',
-        options: { schema: 'prisma/schema.prisma' },
+        options: { schema: `${project.root}/prisma/schema.prisma` },
       },
     },
   });

--- a/packages/nx-prisma/src/run-commands.ts
+++ b/packages/nx-prisma/src/run-commands.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext, getPackageManagerCommand } from '@nrwl/devkit';
-import { getExecOutput, getProjectRoot, startGroup } from '@nx-tools/core';
+import { getExecOutput, startGroup } from '@nx-tools/core';
 
 export interface PrismaBuilderOptions {
   schema?: string;
@@ -9,7 +9,7 @@ export interface PrismaBuilderOptions {
 export interface PrismaCommands<T extends PrismaBuilderOptions> {
   description: string;
   command: string;
-  getArgs: (options: T) => string[];
+  getArgs: (options: T, ctx: ExecutorContext) => string[];
 }
 
 export const runCommand = async <T extends PrismaBuilderOptions>(
@@ -17,13 +17,12 @@ export const runCommand = async <T extends PrismaBuilderOptions>(
   ctx: ExecutorContext,
   { description, command, getArgs }: PrismaCommands<T>
 ): Promise<{ success: true }> => {
-  const cwd = getProjectRoot(ctx);
   const cmd = `${getPackageManagerCommand().exec} ${command}`;
-  const args = getArgs(options);
+  const args = getArgs(options, ctx);
 
   startGroup(description, 'Nx Prisma');
 
-  await getExecOutput(cmd, args, { cwd, ignoreReturnCode: true }).then((res) => {
+  await getExecOutput(cmd, args, { ignoreReturnCode: true }).then((res) => {
     if (res.stderr.length > 0 && res.exitCode != 0) {
       throw new Error(`${res.stderr.trim() ?? 'unknown error'}`);
     }

--- a/packages/nx-prisma/src/utils.ts
+++ b/packages/nx-prisma/src/utils.ts
@@ -1,0 +1,5 @@
+import { ExecutorContext } from '@nrwl/devkit';
+import { getProjectRoot } from '@nx-tools/core';
+import { join } from 'node:path';
+
+export const getDefaultScheme = (ctx: ExecutorContext) => join(getProjectRoot(ctx), 'prisma/schema.prisma');


### PR DESCRIPTION
With nx-prisma  <= v3, you can use a prisma schema from any location, but in v4 the plugin assumes that the scheme is inside the application directory, causing problems in application that uses an schema from a shared library (or whatever place outside of the project folder) like was reported [here](https://github.com/gperdomor/nx-tools/issues/664)...

This MR solve the issue recovering the previous behavior from v3...
