### PR TITLE
fix: executors are not awaited in nx-prisma

### DIFF
--- a/packages/nx-prisma/src/executors/seed/executor.ts
+++ b/packages/nx-prisma/src/executors/seed/executor.ts
@@ -11,7 +11,7 @@ export default async function run(options: SeedExecutorSchema, ctx: ExecutorCont
   const command = `${getPackageManagerCommand().exec} ts-node`;
   const args = getArgs(options, ctx);
 
-  logger.group('Seeding Database', async () => {
+  await logger.group('Seeding Database', async () => {
     await getExecOutput(command, args, { ignoreReturnCode: true }).then((res) => {
       if (res.stderr.length > 0 && res.exitCode != 0) {
         throw new Error(`${res.stderr.trim() ?? 'unknown error'}`);

--- a/packages/nx-prisma/src/run-commands.ts
+++ b/packages/nx-prisma/src/run-commands.ts
@@ -20,7 +20,7 @@ export const runCommand = async <T extends PrismaBuilderOptions>(
   const cmd = `${getPackageManagerCommand().exec} ${command}`;
   const args = getArgs(options, ctx);
 
-  logger.group(description, async () => {
+  await logger.group(description, async () => {
     await getExecOutput(cmd, args, { ignoreReturnCode: true }).then((res) => {
       if (res.stderr.length > 0 && res.exitCode != 0) {
         throw new Error(`${res.stderr.trim() ?? 'unknown error'}`);


### PR DESCRIPTION
Fixes #815 

Command executor has not been awaited since #788, and it caused a bug where nx-prisma's executors immediately exits without running the command.

This PR adds `await` for seed and other commands (except for synchrounously executed command like `migrate` and `reset`) to fix this bug.
