### PR TITLE
feat: add option to configure provenance

### DIFF
--- a/packages/nx-container/src/executors/build/context.ts
+++ b/packages/nx-container/src/executors/build/context.ts
@@ -29,6 +29,7 @@ export interface Inputs {
   noCacheFilters: string[];
   outputs: string[];
   platforms: string[];
+  provenance: string;
   pull: boolean;
   push: boolean;
   secretFiles: string[];
@@ -85,6 +86,7 @@ export async function getInputs(
     noCacheFilters: await getInputList('no-cache-filters', prefix, options['no-cache-filters']),
     outputs: await getInputList('outputs', prefix, options.outputs, true),
     platforms: await getInputList('platforms', prefix, options.platforms),
+    provenance: core.getInput('provenance'),
     pull: core.getBooleanInput('pull', { fallback: `${options.pull || false}` }),
     push: core.getBooleanInput('push', { fallback: `${options.push || false}` }),
     secretFiles: await getInputList('secret-files', prefix, options['secret-files'], true),

--- a/packages/nx-container/src/executors/build/engines/docker/docker.engine.ts
+++ b/packages/nx-container/src/executors/build/engines/docker/docker.engine.ts
@@ -161,6 +161,9 @@ export class Docker extends EngineAdapter {
     if (inputs.platforms.length > 0) {
       args.push('--platform', inputs.platforms.join(','));
     }
+    if (inputs.provenance) {
+      args.push('--provenance', inputs.provenance);
+    }
     await asyncForEach(inputs.secrets, async (secret) => {
       try {
         args.push('--secret', await buildx.getSecretString(secret));

--- a/packages/nx-container/src/executors/build/schema.d.ts
+++ b/packages/nx-container/src/executors/build/schema.d.ts
@@ -69,6 +69,10 @@ export interface DockerBuildSchema {
    */
   platforms?: string[];
   /**
+   * Change or disable provenance attestations for the build result
+   */
+  provenance?: string;
+  /**
    * Always attempt to pull a newer version of the image (default false)
    */
   pull?: boolean;

--- a/packages/nx-container/src/executors/build/schema.json
+++ b/packages/nx-container/src/executors/build/schema.json
@@ -116,6 +116,10 @@
       },
       "description": "List of target platforms for build"
     },
+    "provenance": {
+      "type": "string",
+      "description": "Change or disable provenance attestations for the build result"
+    },
     "pull": {
       "type": "boolean",
       "description": "Always attempt to pull a newer version of the image (default false)",


### PR DESCRIPTION
Because of [how AWS ECR handles provenance information](https://github.com/aws/containers-roadmap/issues/1596) (showing an `Image Index` and two `Image`s for each push), we want to [build with `--provenance=false`](https://docs.docker.com/reference/cli/docker/buildx/build/#provenance).

Hopefully this PR is all it takes to add this capability.

(For more context: https://stackoverflow.com/questions/77207485/why-are-there-extra-untagged-images-in-amazon-ecr-after-doing-docker-push)