### PR TITLE
feat(nx-container): initial support for provenance and sbom

### DIFF
--- a/packages/nx-container/src/executors/build/context.ts
+++ b/packages/nx-container/src/executors/build/context.ts
@@ -1,5 +1,5 @@
-import { ExecutorContext, names } from '@nx/devkit';
 import * as core from '@nx-tools/core';
+import { ExecutorContext, names } from '@nx/devkit';
 import { parse } from 'csv-parse/sync';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -29,8 +29,10 @@ export interface Inputs {
   noCacheFilters: string[];
   outputs: string[];
   platforms: string[];
+  provenance: string;
   pull: boolean;
   push: boolean;
+  sbom: string;
   secretFiles: string[];
   secrets: string[];
   shmSize: string;
@@ -85,6 +87,8 @@ export async function getInputs(
     noCacheFilters: await getInputList('no-cache-filters', prefix, options['no-cache-filters']),
     outputs: await getInputList('outputs', prefix, options.outputs, true),
     platforms: await getInputList('platforms', prefix, options.platforms),
+    provenance: core.getInput('provenance'),
+    sbom: core.getInput('sbom'),
     pull: core.getBooleanInput('pull', { fallback: `${options.pull || false}` }),
     push: core.getBooleanInput('push', { fallback: `${options.push || false}` }),
     secretFiles: await getInputList('secret-files', prefix, options['secret-files'], true),

--- a/packages/nx-container/src/executors/build/engines/docker/docker.engine.ts
+++ b/packages/nx-container/src/executors/build/engines/docker/docker.engine.ts
@@ -1,5 +1,5 @@
-import { ExecutorContext, names } from '@nx/devkit';
 import { asyncForEach, exec, getBooleanInput, getExecOutput, logger } from '@nx-tools/core';
+import { ExecutorContext, names } from '@nx/devkit';
 import * as handlebars from 'handlebars';
 import { randomBytes } from 'node:crypto';
 import { Inputs } from '../../context';
@@ -160,6 +160,12 @@ export class Docker extends EngineAdapter {
     });
     if (inputs.platforms.length > 0) {
       args.push('--platform', inputs.platforms.join(','));
+    }
+    if (inputs.provenance) {
+      args.push('--provenance', inputs.provenance);
+    }
+    if (inputs.sbom) {
+      args.push('--sbom', inputs.sbom);
     }
     await asyncForEach(inputs.secrets, async (secret) => {
       try {

--- a/packages/nx-container/src/executors/build/executor.spec.ts
+++ b/packages/nx-container/src/executors/build/executor.spec.ts
@@ -46,6 +46,7 @@ describe('Build Executor', () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     restore();
   });
 

--- a/packages/nx-container/src/executors/build/schema.d.ts
+++ b/packages/nx-container/src/executors/build/schema.d.ts
@@ -69,6 +69,10 @@ export interface DockerBuildSchema {
    */
   platforms?: string[];
   /**
+   * Change or disable provenance attestations for the build result
+   */
+  provenance?: string;
+  /**
    * Always attempt to pull a newer version of the image (default false)
    */
   pull?: boolean;
@@ -76,6 +80,10 @@ export interface DockerBuildSchema {
    * Push is a shorthand for --output=type=registry (default false)
    */
   push?: boolean;
+  /**
+   * Generate SBOM attestation for the build (shorthand for --attest=type=sbom)
+   */
+  sbom?: string;
   /**
    * List of secrets to expose to the build (eg. key=string, GIT_AUTH_TOKEN=mytoken)
    */

--- a/packages/nx-container/src/executors/build/schema.json
+++ b/packages/nx-container/src/executors/build/schema.json
@@ -116,6 +116,11 @@
       },
       "description": "List of target platforms for build"
     },
+    "provenance": {
+      "type": "string",
+      "description": "Change or disable provenance attestations for the build result"
+    },
+
     "pull": {
       "type": "boolean",
       "description": "Always attempt to pull a newer version of the image (default false)",
@@ -125,6 +130,10 @@
       "type": "boolean",
       "description": "Push is a shorthand for --output=type=registry (default false)",
       "default": false
+    },
+    "sbom": {
+      "type": "string",
+      "description": "Generate SBOM attestation for the build (shorthand for --attest=type=sbom)"
     },
     "secrets": {
       "type": "array",


### PR DESCRIPTION
This adds basic support for `sbom` and `provenance` options in docker engine
Fix #1016 