### PR TITLE
Add build-contexts as part of schema

### DIFF
--- a/plugins/nx-container/src/executors/build/schema.d.ts
+++ b/plugins/nx-container/src/executors/build/schema.d.ts
@@ -21,6 +21,10 @@ export interface DockerBuildSchema {
    */
   'build-args'?: string[];
   /**
+   * List of additional build contexts (e.g., name=path)
+   */
+  'build-contexts'?: string[];
+  /**
    * Builder instance (see setup-buildx action)
    */
   builder?: string;

--- a/plugins/nx-container/src/executors/build/schema.json
+++ b/plugins/nx-container/src/executors/build/schema.json
@@ -34,6 +34,13 @@
       },
       "description": "List of build-time variables"
     },
+    "build-contexts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of additional build contexts (e.g., name=path)"
+    },
     "builder": {
       "type": "string",
       "description": "Builder instance (see setup-buildx action)"


### PR DESCRIPTION
## What is the current behavior?
Behavior all works for docker buildx `--build-context` flag, however it wasn't reflected in the schema and at first glance I thought it wasn't supported.

## What is the new behavior?
the `--build-context` option is now a part of the executor schema. 

## Does this introduce a breaking change?
- [ ] Yes
- [X] No

## Other information

[buildx --build-context](https://github.com/docker/buildx/blob/v0.15.1/docs/reference/buildx_build.md#build-context) is already supported by [nx-tools Inputs](https://github.com/gperdomor/nx-tools/blob/7addcc9297bee9aacc21a8b1ce293754c89115e8/plugins/nx-container/src/executors/build/context.ts#L17) and [mapping the inputs from the executor inputs](https://github.com/gperdomor/nx-tools/blob/7addcc9297bee9aacc21a8b1ce293754c89115e8/plugins/nx-container/src/executors/build/context.ts#L74C1-L75C1) already exists. 

This change simply adds it to schemas.