### PR TITLE
feat(nx-container): quiet logs via environment variable

### DIFF
--- a/packages/core/src/lib/logging.ts
+++ b/packages/core/src/lib/logging.ts
@@ -62,4 +62,13 @@ async function group<T>(name: string, fn: () => Promise<T>): Promise<T> {
   return result;
 }
 
+const noop = () => {};
+
 export const logger = { ...l, startGroup, endGroup, group };
+
+if (process.env['NX_CONTAINER_QUIET']) {
+  for (const key of Object.keys(logger)) {
+    // @ts-ignore
+    logger[key] = noop;
+  }
+}

--- a/plugins/nx-container/docs/inputs.md
+++ b/plugins/nx-container/docs/inputs.md
@@ -29,7 +29,6 @@ Following inputs can be used as `step.with` keys
 | `platforms`           | List/CSV | List of [target platforms](https://github.com/docker/buildx#---platformvaluevalue) for build                                                                                      |
 | `pull`                | Bool     | Always attempt to pull a newer version of the image (default `false`)                                                                                                             |
 | `push`                | Bool     | [Push](https://github.com/docker/buildx#--push) is a shorthand for `--output=type=registry` (default `false`)                                                                     |
-| `quiet`               | Bool     | Run executor without printing engine info                                                                                                                                         |
 | `secret-files`        | List     | List of secret files to expose to the build (eg. key=filename, MY_SECRET=./secret.txt)                                                                                            |
 | `secrets`             | List     | List of secrets to expose to the build (eg. `key=value`, `GIT_AUTH_TOKEN=mytoken`, `NPM_TOKEN=${NPM_TOKEN}` will use the environment variable)                                    |
 | `shm-size`¹           | String   | Size of [`/dev/shm`](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#-size-of-devshm---shm-size) (e.g., `2g`)                                         |
@@ -58,3 +57,9 @@ Following inputs can be used as `step.with` keys
 To check all possible options please check this [schema.json](../src/executors/build/schema.json) file
 
 > For deep explanation about metadata extraction, how the options works and see some config examples, please check [this](https://github.com/crazy-max/ghaction-docker-meta)
+
+### Environment variables
+
+| Name                 | Type    | Description                        |
+| -------------------- | ------- | ---------------------------------- |
+| `NX_CONTAINER_QUIET` | Boolean | Run executor without printing logs |

--- a/plugins/nx-container/src/executors/build/context.ts
+++ b/plugins/nx-container/src/executors/build/context.ts
@@ -10,7 +10,6 @@ import { BuildExecutorSchema } from './schema';
 let _defaultContext, _tmpDir: string;
 
 export interface Inputs {
-  quiet: boolean;
   addHosts: string[];
   allow: string[];
   buildArgs: string[];
@@ -67,7 +66,6 @@ export async function getInputs(
   const prefix = names(ctx?.projectName || '').constantName;
 
   return {
-    quiet: core.getBooleanInput('quiet', { prefix, fallback: `${options.quiet || false}` }),
     addHosts: await getInputList('add-hosts', prefix, options['add-hosts']),
     allow: await getInputList('allow', prefix, options.allow),
     buildArgs: await getInputList('build-args', prefix, options['build-args'], true),

--- a/plugins/nx-container/src/executors/build/engines/docker/docker.engine.ts
+++ b/plugins/nx-container/src/executors/build/engines/docker/docker.engine.ts
@@ -24,20 +24,18 @@ export class Docker extends EngineAdapter {
     // standalone if docker cli not available
     this.standalone = !(await docker.isAvailable());
 
-    if (!inputs.quiet) {
-      await logger.group(`Docker info`, async () => {
-        if (this.standalone) {
-          logger.info('Docker info skipped in standalone mode');
-        } else {
-          await exec('docker', ['version'], {
-            failOnStdErr: false,
-          });
-          await exec('docker', ['info'], {
-            failOnStdErr: false,
-          });
-        }
-      });
-    }
+    await logger.group(`Docker info`, async () => {
+      if (this.standalone) {
+        logger.info('Docker info skipped in standalone mode');
+      } else {
+        await exec('docker', ['version'], {
+          failOnStdErr: false,
+        });
+        await exec('docker', ['info'], {
+          failOnStdErr: false,
+        });
+      }
+    });
 
     if (!(await buildx.isAvailable(this.standalone))) {
       throw new Error(
@@ -47,14 +45,12 @@ export class Docker extends EngineAdapter {
 
     this.buildxVersion = await buildx.getVersion();
 
-    if (!inputs.quiet) {
-      await logger.group(`Buildx version`, async () => {
-        const versionCmd = buildx.getCommand(['version'], this.standalone);
-        await exec(versionCmd.command, versionCmd.args, {
-          failOnStdErr: false,
-        });
+    await logger.group(`Buildx version`, async () => {
+      const versionCmd = buildx.getCommand(['version'], this.standalone);
+      await exec(versionCmd.command, versionCmd.args, {
+        failOnStdErr: false,
       });
-    }
+    });
 
     this.createdBuilder = getBooleanInput('create-builder', {
       prefix: names(ctx?.projectName || '').constantName,

--- a/plugins/nx-container/src/executors/build/engines/kaniko/kaniko.engine.ts
+++ b/plugins/nx-container/src/executors/build/engines/kaniko/kaniko.engine.ts
@@ -24,14 +24,12 @@ export class Kaniko extends EngineAdapter {
       );
     }
 
-    if (!inputs.quiet) {
-      await logger.group(`Kaniko info`, async () => {
-        const cmd = kaniko.getCommand(['version']);
-        await exec(cmd.command, cmd.args, {
-          failOnStdErr: false,
-        });
+    await logger.group(`Kaniko info`, async () => {
+      const cmd = kaniko.getCommand(['version']);
+      await exec(cmd.command, cmd.args, {
+        failOnStdErr: false,
       });
-    }
+    });
 
     this.originalDirs = await readdir('/kaniko');
   }

--- a/plugins/nx-container/src/executors/build/engines/podman/podman.engine.ts
+++ b/plugins/nx-container/src/executors/build/engines/podman/podman.engine.ts
@@ -26,26 +26,22 @@ export class Podman extends EngineAdapter {
       );
     }
 
-    if (!inputs.quiet) {
-      await logger.group(`Podman info`, async () => {
-        await exec('podman', ['version'], {
-          failOnStdErr: false,
-        });
-        await exec('podman', ['info'], {
-          failOnStdErr: false,
-        });
+    await logger.group(`Podman info`, async () => {
+      await exec('podman', ['version'], {
+        failOnStdErr: false,
       });
-    }
+      await exec('podman', ['info'], {
+        failOnStdErr: false,
+      });
+    });
 
     this.podmanVersion = await podman.getVersion();
 
-    if (!inputs.quiet) {
-      await logger.group(`Podman version`, async () => {
-        await exec('podman', ['version'], {
-          failOnStdErr: false,
-        });
+    await logger.group(`Podman version`, async () => {
+      await exec('podman', ['version'], {
+        failOnStdErr: false,
       });
-    }
+    });
   }
 
   async finalize(inputs: Inputs, ctx?: ExecutorContext): Promise<void> {

--- a/plugins/nx-container/src/executors/build/executor.spec.ts
+++ b/plugins/nx-container/src/executors/build/executor.spec.ts
@@ -9,7 +9,6 @@ const options: BuildExecutorSchema = {
   file: 'plugins/nx-container/tests/Dockerfile',
   load: true,
   tags: ['registry/node:latest'],
-  quiet: true,
   metadata: {
     images: ['app/name'],
     tags: ['type=sha'],

--- a/plugins/nx-container/src/executors/build/schema.d.ts
+++ b/plugins/nx-container/src/executors/build/schema.d.ts
@@ -7,7 +7,6 @@
 
 export interface BuildExecutorSchema {
   engine?: 'docker' | 'podman' | 'kaniko';
-  quiet?: boolean;
   /**
    * List of customs host-to-IP mapping (e.g., docker:10.180.0.1)
    */

--- a/plugins/nx-container/src/executors/build/schema.json
+++ b/plugins/nx-container/src/executors/build/schema.json
@@ -9,10 +9,6 @@
       "type": "string",
       "default": "docker"
     },
-    "quiet": {
-      "type": "boolean",
-      "default": false
-    },
     "add-hosts": {
       "type": "array",
       "items": {


### PR DESCRIPTION
Closes #1099

Initially, I wanted to use the existing `quiet` input and choose between the normal logger or the no-op logger. However, the `logger` object is imported in a lot of files, most of which don't have access to the `inputs` data.

So I changed this to an environment variable configuration.

I'm open to update the implementation based on feedback.

Do we still want to keep the `quiet` input, to avoid introducing breaking changes?