### PR TITLE
feat(nx-prisma): add support for all prisma generate options

### DIFF
--- a/plugins/nx-prisma/src/executors/generate/executor.spec.ts
+++ b/plugins/nx-prisma/src/executors/generate/executor.spec.ts
@@ -21,7 +21,9 @@ const context: ExecutorContext = {
 };
 
 export const expectCommandToHaveBeenCalled = (cmd: string, args: string[]) => {
-  expect(getExecOutput).toHaveBeenCalledWith(cmd, args, { ignoreReturnCode: true });
+  expect(getExecOutput).toHaveBeenCalledWith(cmd, args, {
+    ignoreReturnCode: true,
+  });
 };
 
 describe('Generate Executor', () => {
@@ -50,7 +52,7 @@ describe('Generate Executor', () => {
     }
   );
 
-  test.each([['data-proxy'], ['watch']])(
+  test.each([['data-proxy'], ['accelerate'], ['no-engine'], ['no-hints'], ['allow-no-models'], ['watch']])(
     'given %p, should be handled has flag',
     async (flag: keyof GenerateExecutorSchema) => {
       const options: GenerateExecutorSchema = {
@@ -78,8 +80,8 @@ describe('Generate Executor', () => {
     expect(
       expectCommandToHaveBeenCalled('npx prisma generate', [
         '--schema=my-schema.schema',
-        '--data-proxy',
         '--generator=sample-generator',
+        '--data-proxy',
         '--watch',
       ])
     );

--- a/plugins/nx-prisma/src/executors/generate/executor.ts
+++ b/plugins/nx-prisma/src/executors/generate/executor.ts
@@ -18,17 +18,18 @@ const getArgs = (options: GenerateExecutorSchema, ctx: ExecutorContext): string[
 
   args.push(`--schema=${schema}`);
 
-  if (options?.['data-proxy']) {
-    args.push('--data-proxy');
-  }
-
   if (generator) {
     args.push(`--generator=${generator}`);
   }
 
-  if (options?.watch) {
-    args.push('--watch');
-  }
+  // Option list from https://www.prisma.io/docs/orm/reference/prisma-cli-reference#options-1
+  const generatorCommandFlags = ['data-proxy', 'accelerate', 'no-engine', 'no-hints', 'allow-no-models', 'watch'];
+
+  generatorCommandFlags.forEach((flag) => {
+    if (options[flag]) {
+      args.push(`--${flag}`);
+    }
+  });
 
   return args;
 };

--- a/plugins/nx-prisma/src/executors/generate/schema.d.ts
+++ b/plugins/nx-prisma/src/executors/generate/schema.d.ts
@@ -11,9 +11,25 @@ import { PrismaBase } from '../../interfaces';
  */
 export interface GenerateExecutorSchema extends PrismaBase {
   /**
-   * The generate command will generate Prisma Client for use with the Data Proxy.
+   * The generate command will generate Prisma Client for use with the Data Proxy. Deprecated in Prisma ORM 5.2.0 and later.
    */
   'data-proxy'?: boolean;
+  /**
+   * The generate command will generate Prisma Client for use with Prisma Accelerate. Mutually exclusive with --data-proxy and --no-engine. Available in Prisma 5.1.0 and later.  Deprecated in Prisma ORM 5.2.0 and later.
+   */
+  accelerate?: boolean;
+  /**
+   * The generate command will generate Prisma Client without an accompanied engine for use with Prisma Accelerate. Mutually exclusive with --data-proxy and --accelerate. Available in Prisma ORM 5.2.0 and later.
+   */
+  'no-engine'?: boolean;
+  /**
+   * The generate command will generate Prisma Client without usage hints being printed to the terminal. Available in Prisma ORM 5.16.0 and later.
+   */
+  'no-hints'?: boolean;
+  /**
+   * The generate command will generate Prisma Client without generating any models.
+   */
+  'allow-no-models'?: boolean;
   /**
    * Specifies the generator to use for generating prisma client.
    */

--- a/plugins/nx-prisma/src/executors/generate/schema.json
+++ b/plugins/nx-prisma/src/executors/generate/schema.json
@@ -15,7 +15,23 @@
     },
     "data-proxy": {
       "type": "boolean",
-      "description": "The generate command will generate Prisma Client for use with the Data Proxy."
+      "description": "The generate command will generate Prisma Client for use with the Data Proxy. Deprecated in Prisma ORM 5.2.0 and later."
+    },
+    "accelerate": {
+      "type": "boolean",
+      "description": "The generate command will generate Prisma Client for use with Prisma Accelerate. Mutually exclusive with --data-proxy and --no-engine. Available in Prisma 5.1.0 and later.  Deprecated in Prisma ORM 5.2.0 and later."
+    },
+    "no-engine": {
+      "type": "boolean",
+      "description": "The generate command will generate Prisma Client without an accompanied engine for use with Prisma Accelerate. Mutually exclusive with --data-proxy and --accelerate. Available in Prisma ORM 5.2.0 and later."
+    },
+    "no-hints": {
+      "type": "boolean",
+      "description": "The generate command will generate Prisma Client without usage hints being printed to the terminal. Available in Prisma ORM 5.16.0 and later."
+    },
+    "allow-no-models": {
+      "type": "boolean",
+      "description": "The generate command will generate Prisma Client without generating any models."
     },
     "watch": {
       "type": "boolean",


### PR DESCRIPTION
Add support for `prisma generate` options that aren't currently supported:
* `--accelerate`
* `--no-engine`
* `--no-hints`
* `--allow-no-models`

More info: https://www.prisma.io/docs/orm/reference/prisma-cli-reference#generate

This PR allow passing these options as options to the `nx-prisma` plugin