### PR TITLE
feat(nx-container): support for sbom attestations

### DIFF
--- a/packages/nx-container/src/executors/build/context.ts
+++ b/packages/nx-container/src/executors/build/context.ts
@@ -32,6 +32,7 @@ export interface Inputs {
   provenance: string;
   pull: boolean;
   push: boolean;
+  sbom: boolean;
   secretFiles: string[];
   secrets: string[];
   shmSize: string;
@@ -89,6 +90,7 @@ export async function getInputs(
     provenance: core.getInput('provenance'),
     pull: core.getBooleanInput('pull', { fallback: `${options.pull || false}` }),
     push: core.getBooleanInput('push', { fallback: `${options.push || false}` }),
+    sbom: core.getBooleanInput('sbom', { fallback: `${options.sbom || false}` }),
     secretFiles: await getInputList('secret-files', prefix, options['secret-files'], true),
     secrets: await getInputList('secrets', prefix, options.secrets, true),
     shmSize: core.getInput('shm-size', { prefix, fallback: options['shm-size'] }),

--- a/packages/nx-container/src/executors/build/engines/docker/docker.engine.ts
+++ b/packages/nx-container/src/executors/build/engines/docker/docker.engine.ts
@@ -181,6 +181,9 @@ export class Docker extends EngineAdapter {
     if (inputs.githubToken && !buildx.hasGitAuthToken(inputs.secrets) && context.startsWith(defaultContext)) {
       args.push('--secret', await buildx.getSecretString(`GIT_AUTH_TOKEN=${inputs.githubToken}`));
     }
+    if (inputs.sbom) {
+      args.push('--attest', 'type=sbom');
+    }
     if (inputs.shmSize) {
       args.push('--shm-size', inputs.shmSize);
     }

--- a/packages/nx-container/src/executors/build/schema.d.ts
+++ b/packages/nx-container/src/executors/build/schema.d.ts
@@ -103,6 +103,11 @@ export interface BuildExecutorSchema {
    */
   push?: boolean;
   /**
+   * Generate SBOM attestation, shorthand for --attest type=sbom (default false)
+   * @default false
+   */
+  sbom?: boolean;
+  /**
    * List of secrets to expose to the build (eg. key=string, GIT_AUTH_TOKEN=mytoken)
    */
   secrets?: string[];

--- a/packages/nx-container/src/executors/build/schema.json
+++ b/packages/nx-container/src/executors/build/schema.json
@@ -137,6 +137,11 @@
       "description": "Push is a shorthand for --output=type=registry (default false)",
       "default": false
     },
+    "sbom": {
+      "type": "boolean",
+      "description": "Generate SBOM attestation for the build (shorthand for --attest type=sbom)",
+      "default": false
+    },
     "secrets": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## Current Behavior

It is not possible to add the buildx option for SBOM attestations in nx-container (see https://docs.docker.com/build/metadata/attestations/sbom/ )

## Expected Behavior

I would like to enable the SBOM attestations by setting a configuration option "sbom" to true.

This functionality has been part of v5 ( https://github.com/gperdomor/nx-tools/pull/1020/files ), but it seems, it did not make it into v6 (but the "provenance" parameter did...) ?!

## Related Issue(s)

(there were no related issues)
